### PR TITLE
Adding gazebo distro vcs collection

### DIFF
--- a/gazebodistro/collection-ionic.yaml
+++ b/gazebodistro/collection-ionic.yaml
@@ -1,0 +1,63 @@
+---
+repositories:
+  gz-cmake:
+    type: git
+    url: https://github.com/gazebosim/gz-cmake
+    version: main
+  gz-common:
+    type: git
+    url: https://github.com/gazebosim/gz-common
+    version: main
+  gz-fuel-tools:
+    type: git
+    url: https://github.com/gazebosim/gz-fuel-tools
+    version: main
+  gz-sim:
+    type: git
+    url: https://github.com/gazebosim/gz-sim
+    version: main
+  gz-gui:
+    type: git
+    url: https://github.com/gazebosim/gz-gui
+    version: main
+  gz-launch:
+    type: git
+    url: https://github.com/gazebosim/gz-launch
+    version: main
+  gz-math:
+    type: git
+    url: https://github.com/gazebosim/gz-math
+    version: main
+  gz-msgs:
+    type: git
+    url: https://github.com/gazebosim/gz-msgs
+    version: main
+  gz-physics:
+    type: git
+    url: https://github.com/gazebosim/gz-physics
+    version: main
+  gz-plugin:
+    type: git
+    url: https://github.com/gazebosim/gz-plugin
+    version: main
+  gz-rendering:
+    type: git
+    url: https://github.com/gazebosim/gz-rendering
+    version: main
+  gz-sensors:
+    type: git
+    url: https://github.com/gazebosim/gz-sensors
+    version: main
+  gz-transport:
+    type: git
+    url: https://github.com/gazebosim/gz-transport
+    version: main
+  gz-utils:
+    type: git
+    url: https://github.com/gazebosim/gz-utils
+    version: main
+  sdformat:
+    type: git
+    url: https://github.com/gazebosim/sdformat
+    version: main
+


### PR DESCRIPTION
# 🎉 New feature

## Summary

Both [gz-garden](https://github.com/gazebosim/gz-garden/blob/main/gazebodistro/collection-garden.yaml) and [gz-harmonic](https://github.com/gazebosim/gz-harmonic/blob/main/gazebodistro/collection-harmonic.yaml) have collection files in their `gazebodistro` folders that make it easy to pull down the set of packages needed to build the named version of Gz.

I understand there is no versioned branches to point this collection file (instead each package is version = main). But, I still think it greatly aids in setting up a workspace to build on this version of Gz.

## Test it

Pulled down packages locally and built with:
```
vcs import < gz-ionic/gazebodistro/collection-ionic.yaml
colcon build --merge-install
```
